### PR TITLE
[BUGFIX] Add missing module wrapper markup

### DIFF
--- a/Resources/Private/Layouts/BackendModule.html
+++ b/Resources/Private/Layouts/BackendModule.html
@@ -1,4 +1,9 @@
-<h3>
-    <f:render section="Headline"/>
-</h3>
-<f:render section="Content"/>
+<div class="module" data-module-name="{moduleName}">
+    <div class="module-body">
+        <h3>
+            <f:render section="Headline"/>
+        </h3>
+        <f:render section="Content"/>
+    </div>
+</div>
++

--- a/Resources/Private/Templates/BackendModule/Index.html
+++ b/Resources/Private/Templates/BackendModule/Index.html
@@ -13,7 +13,7 @@
         <pre>$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']</pre>
     </p>
 
-    <table border="0" cellspacing="1" cellpadding="0" class="table table-striped table-hover scrollable-table">
+    <table border="0" cellspacing="1" cellpadding="0" class="table table-striped table-hover">
         <thead>
         <tr>
             <td><f:translate key="LLL:EXT:cachemgm/Resources/Private/BackendModule/Language/locallang.xlf:bemodule.cache_name" default="Cache name"/></td>
@@ -42,11 +42,4 @@
         </f:for>
         </tbody>
     </table>
-    <style>
-        .scrollable-table{
-            display: block;
-            overflow: auto;
-            max-height: -webkit-fill-available;
-        }
-    </style>
 </f:section>


### PR DESCRIPTION
I'd like to provide an alternative solution for the scrolling problem in the **cachemgm** module in the TYPO3 backend. It uses two div elements with classes which are used in the modules shipped with the CMS core.

With this the fix with the scrollable table is not required anymore. Additional to this the module content gets the default padding as in other modules. This solution should be closer to the TYPO3 defaults.

Thanks for your feedback.